### PR TITLE
Se corrige la invocación de bibliotecas de BME280 a BMP280

### DIFF
--- a/S4_AnalogRead/DataLoggger2/DataLoggger2.ino
+++ b/S4_AnalogRead/DataLoggger2/DataLoggger2.ino
@@ -1,11 +1,11 @@
 #include <SD.h> //Es la biblioteca
-#include <Adafruit_BME280.h>
+#include <Adafruit_BMP280.h>
 File archivo;
 
 const int LED_SENSOR = 33;
 const int LED_SD = 32;
 const int PHOTORES = 35;
-Adafruit_BME280 bme;
+Adafruit_BMP280 bme;
 char payload[50];
 
 void setup() {


### PR DESCRIPTION
Estabas utilizando la biblioteca incorrecta. Yo uso BME280 porque ese es mi sensor. El barómetro que yo entregué es el BMP280.
Corregí este error en tu código.